### PR TITLE
Update Twilio Helper Library version

### DIFF
--- a/WhatsappMediaTutorial.Tests/Controllers/HomeControllerTest.cs
+++ b/WhatsappMediaTutorial.Tests/Controllers/HomeControllerTest.cs
@@ -25,7 +25,72 @@ namespace WhatsappMediaTutorial.Tests.Controllers
         }
 
         [TestMethod]
-        public void Index()
+        public void IndexWithoutImages_AsksForAnImage()
+        {
+            // Arrange
+            string requestData = "{\n  \"SmsMessageSid\": \"MM19df5a6293470c5e309890648740986a\"," +
+                "\n  \"NumMedia\": \"0\",\n  \"SmsSid\": \"MM19df5a6293470c5e309890648740986a\",\n  \"SmsStatus\": \"received\",\n  " +
+                "\"Body\": \"\",\n  \"To\": \"whatsapp:+14155238886\",\n  \"NumSegments\": \"1\",\n  " +
+                "\"MessageSid\": \"MM19df5a6293470c5e309890648740986a\",\n  \"AccountSid\": \"AC4ee8a4bf66c95837fc46316395718baa\",\n  " +
+                "\"From\": \"whatsapp:+5213321678083\",\n  " +
+                "\"ApiVersion\": \"2010-04-01\",\n  \"ALL_HTTP\": \"HTTP_CACHE_CONTROL:max-age=259200\\r\\nHTTP_CONNECTION:close\\r\\nHTTP_CONTENT_LENGTH:540\\r\\nHTTP_CONTENT_TYPE:application/x-www-form-urlencoded\\r\\nHTTP_ACCEPT:*/*\\r" +
+                "\\nHTTP_HOST:localhost:8081\\r\\nHTTP_USER_AGENT:TwilioProxy/1.1\\r\\nHTTP_X_FORWARDED_FOR:54.225.17.109\\r\\nHTTP_X_ORIGINAL_HOST:b924869a.ngrok.io\\r\\nHTTP_X_TWILIO_SIGNATURE:WctwS3sxSyuCNpIBxIRYE0sCYpY=\\r\\n\",\n  " +
+                "\"ALL_RAW\": \"Cache-Control: max-age=259200\\r\\nConnection: close\\r\\nContent-Length: 540\\r\\nContent-Type: application/x-www-form-urlencoded\\r\\nAccept: */*\\r" +
+                "\\nHost: localhost:8081\\r\\nUser-Agent: TwilioProxy/1.1\\r\\nX-Forwarded-For: 54.225.17.109\\r\\nX-Original-Host: b924869a.ngrok.io\\r" +
+                "\\nX-Twilio-Signature: WctwS3sxSyuCNpIBxIRYE0sCYpY=\\r\\n\",\n  \"APPL_MD_PATH\": \"/LM/W3SVC/3/ROOT\",\n  " +
+                "\"APPL_PHYSICAL_PATH\": \"C:\\\\Users\\\\Jose Oliveros\\\\source\\\\repos\\\\WhatsappMediaTutorial\\\\WhatsappMediaTutorial\\\\\",\n  \"AUTH_TYPE\": \"\",\n  \"AUTH_USER\": \"\",\n  " +
+                "\"AUTH_PASSWORD\": \"\",\n  \"LOGON_USER\": \"\",\n  \"REMOTE_USER\": \"\",\n  \"CERT_COOKIE\": \"\",\n  \"CERT_FLAGS\": \"\",\n  \"CERT_ISSUER\": \"\",\n  \"CERT_KEYSIZE\": \"\",\n  " +
+                "\"CERT_SECRETKEYSIZE\": \"\",\n  \"CERT_SERIALNUMBER\": \"\",\n  \"CERT_SERVER_ISSUER\": \"\",\n  \"CERT_SERVER_SUBJECT\": \"\",\n  \"CERT_SUBJECT\": \"\",\n  " +
+                "\"CONTENT_LENGTH\": \"540\",\n  \"CONTENT_TYPE\": \"application/x-www-form-urlencoded\",\n  \"GATEWAY_INTERFACE\": \"CGI/1.1\",\n  \"HTTPS\": \"off\",\n  \"HTTPS_KEYSIZE\": \"\",\n  " +
+                "\"HTTPS_SECRETKEYSIZE\": \"\",\n  \"HTTPS_SERVER_ISSUER\": \"\",\n  \"HTTPS_SERVER_SUBJECT\": \"\",\n  \"INSTANCE_ID\": \"3\",\n  \"INSTANCE_META_PATH\": \"/LM/W3SVC/3\",\n  " +
+                "\"LOCAL_ADDR\": \"::1\",\n  \"PATH_INFO\": \"/WhatsAppMedia/Create\",\n  " +
+                "\"PATH_TRANSLATED\": \"C:\\\\Users\\\\Jose Oliveros\\\\source\\\\repos\\\\WhatsappMediaTutorial\\\\WhatsappMediaTutorial\\\\WhatsAppMedia\\\\Create\",\n  \"QUERY_STRING\": \"\",\n  " +
+                "\"REMOTE_ADDR\": \"::1\",\n  \"REMOTE_HOST\": \"::1\",\n  \"REMOTE_PORT\": \"50371\",\n  \"REQUEST_METHOD\": \"POST\",\n  \"SCRIPT_NAME\": \"/WhatsAppMedia/Create\",\n  " +
+                "\"SERVER_NAME\": \"localhost\",\n  \"SERVER_PORT\": \"8081\",\n  \"SERVER_PORT_SECURE\": \"0\",\n  \"SERVER_PROTOCOL\": \"HTTP/1.1\",\n  \"SERVER_SOFTWARE\": \"Microsoft-IIS/10.0\",\n  " +
+                "\"URL\": \"/WhatsAppMedia/Create\",\n  \"HTTP_CACHE_CONTROL\": \"max-age=259200\",\n  \"HTTP_CONNECTION\": \"close\",\n  \"HTTP_CONTENT_LENGTH\": \"540\",\n  " +
+                "\"HTTP_CONTENT_TYPE\": \"application/x-www-form-urlencoded\",\n  \"HTTP_ACCEPT\": \"*/*\",\n  \"HTTP_HOST\": \"localhost:8081\",\n  \"HTTP_USER_AGENT\": \"TwilioProxy/1.1\",\n  " +
+                "\"HTTP_X_FORWARDED_FOR\": \"54.225.17.109\",\n  \"HTTP_X_ORIGINAL_HOST\": \"b924869a.ngrok.io\",\n  \"HTTP_X_TWILIO_SIGNATURE\": \"WctwS3sxSyuCNpIBxIRYE0sCYpY=\"\n}";
+
+            var rawParams = JsonConvert.DeserializeObject<Dictionary<string, string>>(requestData);
+            var _params = new NameValueCollection();
+            var formCollection = new FormCollection();
+
+            foreach (var pair in rawParams)
+            {
+                _params.Add(pair.Key, pair.Value);
+                formCollection.Add(pair.Key, pair.Value);
+            }
+
+            var request = new Mock<HttpRequestBase>();
+            request.SetupGet(x => x.Params).Returns(_params);
+            var context = new Mock<HttpContextBase>();
+            context.SetupGet(x => x.Request).Returns(request.Object);
+
+            var controllerMock = new Mock<WhatsAppMediaController>() { CallBase = true };
+
+            // Mock WebClient
+            var webClientMock = new Mock<SystemWebClient>();
+            webClientMock.Setup(w => w.DownloadFile(It.IsAny<string>(), It.IsAny<string>()));
+            controllerMock.Setup(c => c.webClient()).Returns(webClientMock.Object);
+
+            controllerMock.Object.ControllerContext = new ControllerContext(context.Object, new RouteData(), controllerMock.Object);
+
+            // Act
+            TwiMLResult result = controllerMock.Object.Create(formCollection)
+                as TwiMLResult;
+
+            var response = new MessagingResponse();
+            response.Message("Send us an image!");
+
+            var expectedTwimlResult = new TwiMLResult(response);
+
+            // Assert
+            Assert.AreEqual(expectedTwimlResult.Data.ToString(), result.Data.ToString());
+        }
+
+
+        [TestMethod]
+        public void IndexWithAnImage_SendsBackAnImage()
         {
             // Arrange
             string requestData = "{\n  \"MediaContentType0\": \"image/jpeg\",\n  \"SmsMessageSid\": \"MM19df5a6293470c5e309890648740986a\"," +
@@ -80,10 +145,13 @@ namespace WhatsappMediaTutorial.Tests.Controllers
             TwiMLResult result = controllerMock.Object.Create(formCollection)
                 as TwiMLResult;
 
-            var expectedTwimlResponse = new MessagingResponse();
-            expectedTwimlResponse.Message("Thanks for the image(s)");
-            expectedTwimlResponse.Append(new Media(WhatsAppMediaController.GOOD_BOY_URL));
-            var expectedTwimlResult = new TwiMLResult(expectedTwimlResponse);
+            var response = new MessagingResponse();
+            var message = new Message();
+            message.Body("Thanks for the image! Here's one for you!");
+            message.Media(WhatsAppMediaController.GOOD_BOY_URL);
+            response.Append(message);
+
+            var expectedTwimlResult = new TwiMLResult(response);
 
             // Assert
             Assert.AreEqual(expectedTwimlResult.Data.ToString(), result.Data.ToString());

--- a/WhatsappMediaTutorial/Controllers/HomeController.cs
+++ b/WhatsappMediaTutorial/Controllers/HomeController.cs
@@ -33,8 +33,10 @@ namespace WhatsappMediaTutorial.Controllers
 
             if (numMedia > 0)
             {
-                response.Message("Thanks for the image! Here's one for you!");
-                response.Append(new Media(GOOD_BOY_URL));
+                var message = new Message();
+                message.Body("Thanks for the image! Here's one for you!");
+                message.Media(GOOD_BOY_URL);
+                response.Append(message);
             } else
             {
                 response.Message("Send us an image!");

--- a/WhatsappMediaTutorial/WhatsappMediaTutorial.csproj
+++ b/WhatsappMediaTutorial/WhatsappMediaTutorial.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props')" />
   <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props" Condition="Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.Default.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -126,14 +126,14 @@
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.WebPages.Razor.dll</HintPath>
     </Reference>
-    <Reference Include="Twilio, Version=5.30.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Twilio.5.30.0\lib\net451\Twilio.dll</HintPath>
+    <Reference Include="Twilio, Version=5.38.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Twilio.5.38.0\lib\net451\Twilio.dll</HintPath>
     </Reference>
     <Reference Include="Twilio.AspNet.Common, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Twilio.AspNet.Common.5.20.1\lib\net45\Twilio.AspNet.Common.dll</HintPath>
+      <HintPath>..\packages\Twilio.AspNet.Common.5.33.1\lib\net45\Twilio.AspNet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Twilio.AspNet.Mvc, Version=5.20.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Twilio.AspNet.Mvc.5.20.1\lib\net451\Twilio.AspNet.Mvc.dll</HintPath>
+    <Reference Include="Twilio.AspNet.Mvc, Version=5.33.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Twilio.AspNet.Mvc.5.33.1\lib\net451\Twilio.AspNet.Mvc.dll</HintPath>
     </Reference>
     <Reference Include="WebGrease">
       <Private>True</Private>

--- a/WhatsappMediaTutorial/packages.config
+++ b/WhatsappMediaTutorial/packages.config
@@ -21,8 +21,8 @@
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
   <package id="popper.js" version="1.14.3" targetFramework="net472" />
   <package id="System.IdentityModel.Tokens.Jwt" version="5.4.0" targetFramework="net472" />
-  <package id="Twilio" version="5.30.0" targetFramework="net472" />
-  <package id="Twilio.AspNet.Common" version="5.20.1" targetFramework="net472" />
-  <package id="Twilio.AspNet.Mvc" version="5.20.1" targetFramework="net472" />
+  <package id="Twilio" version="5.38.0" targetFramework="net472" />
+  <package id="Twilio.AspNet.Common" version="5.33.1" targetFramework="net472" />
+  <package id="Twilio.AspNet.Mvc" version="5.33.1" targetFramework="net472" />
   <package id="WebGrease" version="1.6.0" targetFramework="net472" />
 </packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: 1.0.{build}
 branches:
+  except:
+  - gh-pages
 before_build:
 - ps: nuget restore
 build:


### PR DESCRIPTION
Using the older version of the library I get the following warning message in the console and don't receive any image.
```
Warning - 12200
Schema validation warning
The provided XML does not conform to the Twilio Markup XML schema. Please refer to the specific error and correct the problem.
```

With this fix, everything works as expected.